### PR TITLE
Fix sssd.conf update in prepare

### DIFF
--- a/SCAutolib/controller.py
+++ b/SCAutolib/controller.py
@@ -234,6 +234,7 @@ class Controller:
                 key="matchrule",
                 value=f"<SUBJECT>.*CN={new_user.username}.*")
             self.sssd_conf.save()
+            self.sssd_conf.update_default_content()
             run(["systemctl", "restart", "sssd"])
             logger.debug(f"Match rule for user {new_user.username} is added "
                          f"to /etc/sssd/sssd.conf")

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with readme.open() as f:
 
 setup(
     name="SCAutolib",
-    version="1.0.15",
+    version="1.0.16",
     description=description,
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Method prepare should update backup file with default sssd.conf after it applies changes to sssd.conf. Adding this step to setup_user method as it is probably the last method executed during prepare.