### PR TITLE
Modify mechanism to obtain a file from IPA server

### DIFF
--- a/SCAutolib/__init__.py
+++ b/SCAutolib/__init__.py
@@ -33,7 +33,7 @@ schema_cas = Schema(And(
     Use(dict),
     # Check that CA section contains at least one and maximum
     # two entries
-    lambda l: 1 <= len(l.keys()) <= 2,
+    lambda l: 1 <= len(l.keys()) <= 2,  # noqa: E741
     {Optional("local_ca"): {
         Optional("dir", default=Path("/etc/SCAutolib/ca")): Use(Path)},
         Optional("ipa"): {

--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,11 @@ with readme.open() as f:
 
 setup(
     name="SCAutolib",
-    version="1.0.16",
+    version="1.0.17",
     description=description,
     long_description=long_description,
     long_description_content_type='text/markdown',
-    url="https://github.com/x00Pavel/SCAutolib",
+    url="https://github.com/redhat-qe-security/SCAutolib",
     author="Pavel Yadlouski",
     author_email="pyadlous@redhat.com",
     classifiers=[


### PR DESCRIPTION
To execute tests for kerberos user one need to have IPA server running. As a part of client system setup, the script generated on IPA server is executed on the client. This library tried to generate the script on IPA server using ssh + command and download the script from the server. However, it may be more convenient to to do this manually. This PR modify SCAutolib to check for presence of the script and try to generate it on the server only if it's not found on client machine.