### PR TITLE
Updates to support Fedora

### DIFF
--- a/SCAutolib/models/gui.py
+++ b/SCAutolib/models/gui.py
@@ -8,6 +8,8 @@ import pytesseract
 import uinput
 
 from SCAutolib import run, logger
+from SCAutolib.enums import OSVersion
+from SCAutolib.utils import _get_os_version
 
 
 class Screen:
@@ -385,3 +387,34 @@ class GUI:
             if selection.sum() != 0:
                 raise Exception(f"The key='{key}' was found "
                                 f"in the screenshot {screenshot}")
+
+    @log_decorator
+    def check_home_screen(self, polarity: bool = True):
+        """
+        Check for the home screen to determine if user is logged in
+
+        If OS version is defined as Fedora, we set the text for which to
+        search to "tosearch" instead of the original "Activities". In later
+        versions of Fedora, "Activities" text is no longer visible. "tosearch"
+        should be visible on the login screen as the search bar is still
+        present.
+
+        After defining polarity and the string to check, run the appropriate
+        function with the string to search for.
+
+        :param polarity: Define whether to search for presence or absence of
+            string indicating home screen is displayed.
+        """
+        if polarity is True:
+            func_str = 'assert_text'
+        else:
+            func_str = 'assert_no_text'
+
+        os_version = _get_os_version()
+        if os_version == OSVersion.Fedora:
+            check_str = 'tosearch'
+        else:
+            check_str = 'Activities'
+
+        func = getattr(self, func_str)
+        func(check_str)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ with readme.open() as f:
     long_description = f.read()
 
 graphical_reqs = [
-    'python-uinput',
     'opencv-python',
     'pandas',
     'numpy',
@@ -25,7 +24,7 @@ graphical_reqs = [
 
 setup(
     name="SCAutolib",
-    version="3.1.2",
+    version="3.2.0",
     description=description,
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
controller.py:
- dnf groups 'Server with GUI' and 'Smart Card Support' do not exist in Fedora.  Running dnf installs for minimal packages in these cases.
- python3-uinput is needed in newer version of Fedora instead of the older python-uinput used from Pypi.  Older version uses a deprecated sysconfig variable (SO) which is fixed in python3-uinput.
- rsyslog is needed by the tests for checking /var/log/secure.

setup.py:
- dropping python-uinput to let the controller install the appropriate version.