### PR TITLE
SCAutolib: Minor changes  && models/gui.py: create an HTML file

### DIFF
--- a/SCAutolib/controller.py
+++ b/SCAutolib/controller.py
@@ -447,6 +447,9 @@ class Controller:
                 cache_file.unlink()
         logger.debug("Removed opensc file cache")
 
+        # file only created in graphical mode that is why it is removed.
+        self.dconf_file.remove()
+
         self.sssd_conf.restore()
         pcscd_service = File("/usr/lib/systemd/system/pcscd.service")
         pcscd_service.restore()

--- a/SCAutolib/models/CA.py
+++ b/SCAutolib/models/CA.py
@@ -66,12 +66,13 @@ class BaseCA:
             root_cert = f_cert.read()
 
         if self._ca_pki_db.exists():
+            with self._ca_pki_db.open() as f:
+                with self._ca_original_path.open('w') as backup:
+                    backup.write(f.read())
             # Check if current CA cert is already present in the sssd auth db
             with self._ca_pki_db.open("a+") as f:
                 f.seek(0)
                 data = f.read()
-                with self._ca_original_path.open('w') as backup:
-                    backup.write(data)
                 if root_cert not in data:
                     f.write(root_cert)
         else:

--- a/SCAutolib/models/file.py
+++ b/SCAutolib/models/file.py
@@ -81,6 +81,16 @@ class File:
             with self._template.open() as t:
                 self._default_parser.read_file(t)
 
+    def remove(self):
+        """
+        Removes the file if it exists.
+        """
+        if self._conf_file.exists():
+            self._conf_file.unlink()
+            logger.debug(
+                f"Removed file {self._conf_file}."
+            )
+
     def set(self, key: str, value: Union[int, str, bool], section: str = None,
             separator: str = "="):
         """
@@ -246,6 +256,10 @@ class File:
             original_path.unlink()
             logger.debug(
                 f"File {self._conf_file} is restored to {original_path}"
+            )
+        else:
+            logger.debug(
+                f"File {self._conf_file} was not backed up. Nothing to do."
             )
 
 

--- a/SCAutolib/models/gui.py
+++ b/SCAutolib/models/gui.py
@@ -57,8 +57,7 @@ class Screen:
 
 
 class Mouse:
-    """Controls the mouse of the system under test
-    """
+    """Controls the mouse of the system under test"""
 
     def __init__(self):
         run(['modprobe', 'uinput'], check=True)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ graphical_reqs = [
 
 setup(
     name="SCAutolib",
-    version="3.2.1",
+    version="3.2.2",
     description=description,
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ graphical_reqs = [
 
 setup(
     name="SCAutolib",
-    version="3.2.0",
+    version="3.2.1",
     description=description,
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
1) Fixing the issue with sssd.conf not restored correctly after cleanup.
2) Fixing typo in gui.py.
3) Removing gnome_disable_welcome on cleanup. This file is only created
    in graphical mode.
4) Gui class creates, on top of the terminal output, logs in HTML file.
    Screenshots now can be shown alongside the test logs. Also Gui class was
    extended to have configurable results dir name so we can have more
    detailed directories in results rather than a simple timestamp.

Also addressing [issue#120](https://github.com/redhat-qe-security/SCAutolib/issues/120)