### PR TITLE
Cleanup SSSD caches

### DIFF
--- a/SCAutolib/controller.py
+++ b/SCAutolib/controller.py
@@ -449,6 +449,12 @@ class Controller:
                 cache_file.unlink()
         logger.debug("Removed opensc file cache")
 
+        sssd_cache_dir = Path(os.path.expanduser('~sssd') + "/.cache/opensc/")
+        if sssd_cache_dir.exists():
+            for cache_file in sssd_cache_dir.iterdir():
+                cache_file.unlink()
+        logger.debug("Removed opensc file cache for sssd user")
+
         # file only created in graphical mode that is why it is removed.
         self.dconf_file.remove()
 

--- a/SCAutolib/utils.py
+++ b/SCAutolib/utils.py
@@ -145,6 +145,7 @@ def load_token(card_name: str = None, update_sssd: bool = False):
                       key="matchrule",
                       value=f"<SUBJECT>.*CN={card.CN}.*")
         sssd_conf.save()
+        run(["sss_cache", "-E"])
         run(["systemctl", "restart", "sssd"])
     return card
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ graphical_reqs = [
 
 setup(
     name="SCAutolib",
-    version="3.3.3",
+    version="3.3.4",
     description=description,
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
The SSSD runs under sssd user in RHEL 10 so there might be opensc file cache created under the provided path.

The SSSD has also separate cache, that should be cleaned and I did not find it in any other place (correct me if I missed this).