### PR TITLE
Improve logging

### DIFF
--- a/SCAutolib/__init__.py
+++ b/SCAutolib/__init__.py
@@ -7,10 +7,12 @@ from schema import Schema, Use, Or, And, Optional
 
 from SCAutolib.enums import CardType, UserType
 
-fmt = "%(name)s:%(module)s.%(funcName)s.%(lineno)d [%(levelname)s] %(message)s"
+fmt = {"%(asctime)s %(name)s:%(module)s.%(funcName)s.%(lineno)d "
+       "[%(levelname)s] %(message)s"}
 date_fmt = "%H:%M:%S"
 coloredlogs.install(level="DEBUG", fmt=fmt, datefmt=date_fmt,
-                    field_styles={'levelname': {'bold': True, 'color': 'blue'}})
+                    field_styles={'levelname': {'bold': True, 'color': 'blue'},
+                                  'asctime': {'color': 'green'}})
 logger = logging.getLogger(__name__)
 # Disable logs from imported packages
 logging.getLogger("paramiko").setLevel(logging.WARNING)

--- a/SCAutolib/models/gui.py
+++ b/SCAutolib/models/gui.py
@@ -74,6 +74,9 @@ class Screen:
 
             if out.returncode == 0:
                 captured = True
+            else:
+                logger.debug(f"ffmpeg failed with {out.returncode}. "
+                             f"stdout: {out.stdout}, stderr: {out.stderr}")
 
         if not captured:
             raise Exception('Could not capture screenshot within timeout.')

--- a/SCAutolib/models/gui.py
+++ b/SCAutolib/models/gui.py
@@ -292,7 +292,9 @@ class GUI:
                 "<body style=\"background-color:#000\">\n"
             )
 
-        fmt = "<span style=\"color:white;\">"
+        fmt = "<span style=\"color:limegreen;\">"
+        fmt += "%(asctime)s</span> "
+        fmt += "<span style=\"color:white;\">"
         fmt += "%(name)s:%(module)s.%(funcName)s.%(lineno)d </span>"
         fmt += "<span style=\"color:royalblue;\">[%(levelname)s] </span>"
         fmt += "<span style=\"color:limegreen;\">%(message)s</span>"

--- a/SCAutolib/models/gui.py
+++ b/SCAutolib/models/gui.py
@@ -1,4 +1,3 @@
-import copy
 import inspect
 import os
 from os.path import join
@@ -13,28 +12,6 @@ import logging
 
 from SCAutolib import run, logger
 from SCAutolib.isDistro import isDistro
-
-
-class HTMLFileHandler(logging.FileHandler):
-    """Extending FileHandler to work with HTML files."""
-
-    def __init__(
-            self, filename, mode='a', encoding=None, delay=False, errors=None):
-        """
-        A handler class which writes formatted logging records to disk HTML
-        files.
-        """
-        super(HTMLFileHandler, self).__init__(
-            filename, mode, encoding, delay, errors
-        )
-
-    def emit(self, record: logging.LogRecord) -> None:
-        """
-        Do whatever it takes to actually log the specified logging record.
-        """
-        custom_record = copy.deepcopy(record)
-        custom_record.msg = str(record.msg).rstrip().replace("\n", "<br>\n")
-        return super().emit(custom_record)
 
 
 class Screen:
@@ -292,7 +269,7 @@ class GUI:
                 "initial-scale=1.0\">\n"
                 "<title>Test Results</title>\n"
                 "</head>\n"
-                "<body style=\"background-color:#000\">\n"
+                "<body style=\"background-color:#000;\">\n"
             )
 
         fmt = "<span style=\"color:limegreen;\">"
@@ -300,8 +277,8 @@ class GUI:
         fmt += "<span style=\"color:white;\">"
         fmt += "%(name)s:%(module)s.%(funcName)s.%(lineno)d </span>"
         fmt += "<span style=\"color:royalblue;\">[%(levelname)s] </span>"
-        fmt += "<span style=\"color:limegreen;\">%(message)s</span>"
-        self.fileHandler = HTMLFileHandler(self.html_file)
+        fmt += "<pre style=\"color:limegreen;\">%(message)s</pre>"
+        self.fileHandler = logging.FileHandler(self.html_file)
         self.fileHandler.setLevel(logging.DEBUG)
         self.fileHandler.setFormatter(
             logging.Formatter("<p>" + fmt + "</p>")

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ graphical_reqs = [
 
 setup(
     name="SCAutolib",
-    version="3.3.4",
+    version="3.3.5",
     description=description,
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This adds just few minor changes that I found helpful while trying to debug some issues on the way:
 * Having a date in the log messages helps to align logs from journal to the events in the library log
 * When taking screenshot fails, its helpful to see a stderr
 * HTML output of python backtraces or formatted `tesseract` outputs removes the needed whitespaces. Printing messages "preformatted" keeps whitespace and makes it easier to read.

The last change likely makes some part of the custom logging no longer needed so it might need some love.