### PR TITLE
models/gui: fix determination of latest image id

### DIFF
--- a/SCAutolib/models/gui.py
+++ b/SCAutolib/models/gui.py
@@ -26,11 +26,12 @@ class Screen:
 
         taken_images = [str(image).split('/')[-1]
                         for image in Path(directory).iterdir()]
-        taken_images.sort(reverse=True)
+        taken_image_ids = [int(image.split('.')[0]) for image in taken_images]
+        taken_image_ids.sort(reverse=True)
 
         self.screenshot_num = 1
         if len(taken_images) > 0:
-            self.screenshot_num = int(taken_images[0].split('.')[0]) + 1
+            self.screenshot_num = taken_image_ids[0] + 1
 
     def screenshot(self, timeout: float = 30):
         """Runs ffmpeg to take a screenshot.


### PR DESCRIPTION
**The problem:** 
We have a directory in GUI testing where we have all the screenshots taken during GUI testing. 
We were taking all the files, sorting them, and then getting the last one and determining the next available ID. This created a problem when we had files 1.png, 2.png, and 10.png cause it sorted like ['1.png', '10.png', '2.png'], so the issue thought the next available was id 3, where it was id 11. 
This caused the overriding of some files. 
This problem appears only when we are using the CLI version of GUI testing.   

**The solution:** 
First, get all the filenames, convert them to integers, and then sort those integers to determine the last ID used and the next available one. 